### PR TITLE
Improve Serverless Logs command

### DIFF
--- a/src/core/default/commands/function/logs.py
+++ b/src/core/default/commands/function/logs.py
@@ -40,7 +40,6 @@ class show_logs(BaseCommand):
         )
 
     def command(self, *args, **kwargs) -> None:
-        print("entrou")
         (
             component_name,
             function_name,
@@ -50,11 +49,7 @@ class show_logs(BaseCommand):
 
         tail_val = kwargs.get("tail")
         number_val = kwargs.get("number")
-        print(str(number_val))
 
-        print("teste")
-        print(component_name)
-        print(function_name)
         cloud_name = get_cloud_id_from_cdev_name(component_name, function_name).split(
             ":"
         )[-1]


### PR DESCRIPTION
The command for getting the logs of a Serverless Function needs to be improved:

- [ ]  Implement the `--tail` option to allow users to get the last part of the logs only
    - [ ]  Implement the `--number` command that limits the number of logs to show
- [ ]  Implement Aws side filtering, this will allow them to filter the logs on the Aws side instead of pulling all logs and then filtering. Extra CLI option.
    - [https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html)
- [ ]  Currently there is bug that only pulls the first 50 sets of cloudwatch log groups and therefore, if the logs are long enough, it does not get all logs.