### PR TITLE
Add more options to the Serverless Function around performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All release will have a corresponding git tag.
 - Update imports to be absolute when possible
 - Add function to parse qualified resources into its parts
 - Add support for lambda functions to update the handler
+- Add option to set your memory, storage and timeout on serverless functions
 - Add user input for setting artifact bucket when creating a new project
 - Added query, tail and limit args to logging function
 

--- a/src/core/constructs/types.py
+++ b/src/core/constructs/types.py
@@ -11,6 +11,7 @@ from core.constructs.cloud_output import (
 
 
 cdev_str = TypeVar("cdev_str", str, Cloud_Output_Str)
+cdev_int = TypeVar("cdev_int", int, Cloud_Output_Int)
 cdev_str_model = TypeVar("cdev_str_model", str, cloud_output_dynamic_model)
 
 F = TypeVar("F", bound=Callable[..., Any])

--- a/src/core/default/mappers/simple/lambda_deployer.py
+++ b/src/core/default/mappers/simple/lambda_deployer.py
@@ -125,6 +125,9 @@ def _create_simple_lambda(
         "Architectures": [arch],
         "Role": role_arn,
         "Handler": resource.configuration.handler,
+        "MemorySize": resource.configuration.memory_size,
+        "EphemeralStorage": {"Size": resource.configuration.storage},
+        "Timeout": resource.configuration.timeout,
         "Code": {"S3Bucket": artifact_bucket, "S3Key": keyname},
         "Environment": {"Variables": resource.configuration.environment_variables._d}
         if resource.configuration.environment_variables

--- a/src/core/default/mappers/simple/lambda_deployer.py
+++ b/src/core/default/mappers/simple/lambda_deployer.py
@@ -320,11 +320,16 @@ def __update_configuration_basic(
     previous_configuration: simple_xlambda.simple_function_configuration_model,
     new_configuration: simple_xlambda.simple_function_configuration_model,
 ) -> None:
+    print(previous_configuration)
+    print(new_configuration)
     if previous_configuration == new_configuration:
         log.debug("Simple lambda, basic configuration didn't change")
     else:
         log.debug("Simple lambda, basic configuration modified")
         updated_configuration["Handler"] = new_configuration.handler
+        updated_configuration["MemorySize"] = new_configuration.memory_size
+        updated_configuration["Timeout"] = new_configuration.timeout
+        updated_configuration["EphemeralStorage"] = {"Size": new_configuration.storage}
 
 
 def __update_configuration_environment_variables(

--- a/src/core/default/mappers/simple/lambda_deployer.py
+++ b/src/core/default/mappers/simple/lambda_deployer.py
@@ -320,8 +320,6 @@ def __update_configuration_basic(
     previous_configuration: simple_xlambda.simple_function_configuration_model,
     new_configuration: simple_xlambda.simple_function_configuration_model,
 ) -> None:
-    print(previous_configuration)
-    print(new_configuration)
     if previous_configuration == new_configuration:
         log.debug("Simple lambda, basic configuration didn't change")
     else:

--- a/src/core/default/resources/simple/xlambda.py
+++ b/src/core/default/resources/simple/xlambda.py
@@ -21,7 +21,7 @@ from core.constructs.resource import (
     PermissionsGrantableMixin,
 )
 from core.constructs.models import frozendict, ImmutableModel
-from core.constructs.types import cdev_str_model, cdev_str
+from core.constructs.types import cdev_str_model, cdev_str, cdev_int
 
 from core.utils import hasher
 from core.utils.platforms import lambda_python_environment, get_current_closest_platform
@@ -137,9 +137,9 @@ class SimpleFunctionConfiguration:
     def __init__(
         self,
         handler: cdev_str,
-        memory_size: cdev_str,
-        timeout: cdev_str,
-        storage: cdev_str,
+        memory_size: cdev_int,
+        timeout: cdev_int,
+        storage: cdev_int,
         description: cdev_str = "",
         environment_variables: Dict[str, cdev_str] = {}
     ) -> None:
@@ -367,7 +367,7 @@ def simple_function_annotation(
     events: List[Event] = [],
     environment={},
     memory_size: int = 128,
-    timeout: int = 3,
+    timeout: int = 30,
     storage: int = 512,
     permissions: List[Union[Permission, PermissionArn]] = [],
     override_platform: lambda_python_environment = None,
@@ -381,7 +381,7 @@ def simple_function_annotation(
         events (List[Event], optional): List of event triggers for the function. Defaults to [].
         environment (dict, optional): Dictionary to apply to the Environment Variables of the deployed function. Defaults to {}.
         memory_size (int, optional): Memory Size of you lambda in MB. Default is 128.
-        timeout (int, optional): Timeout of your lambda in seconds. Default is 3 sec and up to 900.
+        timeout (int, optional): Timeout of your lambda in seconds. Default is 30 sec and up to 900.
         storage (int, optional): Storage of your lambda in MB. Default is 512 MB and can be up to 10240.
         permissions (List[Union[Permission, PermissionArn]], optional): List of Permissions to grant to the Function. Defaults to [].
         override_platform (lambda_python_environment, optional): Option to override the deployment platform in the Cloud. Defaults to None.

--- a/src/core/default/resources/simple/xlambda.py
+++ b/src/core/default/resources/simple/xlambda.py
@@ -121,6 +121,9 @@ class simple_function_configuration_model(ImmutableModel):
     handler: str
     description: Optional[cdev_str_model]
     environment_variables: frozendict
+    memory_size: int
+    timeout: int
+    storage: int
 
     class Config:
         use_enum_values = True
@@ -134,8 +137,11 @@ class SimpleFunctionConfiguration:
     def __init__(
         self,
         handler: cdev_str,
+        memory_size: cdev_str,
+        timeout: cdev_str,
+        storage: cdev_str,
         description: cdev_str = "",
-        environment_variables: Dict[str, cdev_str] = {},
+        environment_variables: Dict[str, cdev_str] = {}
     ) -> None:
         """
         Args:
@@ -144,6 +150,9 @@ class SimpleFunctionConfiguration:
             environment_variables (Dict[str, cdev_str], optional): A dict of overriding variabled for the Environment. Defaults to {}.
         """
         self.handler = handler
+        self.memory_size = memory_size
+        self.timeout = timeout
+        self.storage = storage
         self.description = description
         self.environment_variables = environment_variables
 
@@ -152,6 +161,15 @@ class SimpleFunctionConfiguration:
             handler=self.handler.render()
             if isinstance(self.handler, Cloud_Output_Dynamic)
             else self.handler,
+            memory_size=self.memory_size.render()
+            if isinstance(self.memory_size, Cloud_Output_Dynamic)
+            else self.memory_size,
+            timeout=self.timeout.render()
+            if isinstance(self.timeout, Cloud_Output_Dynamic)
+            else self.timeout,
+            storage=self.storage.render()
+            if isinstance(self.storage, Cloud_Output_Dynamic)
+            else self.storage,
             description=self.description.render()
             if isinstance(self.description, Cloud_Output_Dynamic)
             else self.description,
@@ -176,6 +194,9 @@ class SimpleFunctionConfiguration:
         return hasher.hash_list(
             [
                 self.handler,
+                self.memory_size,
+                self.timeout,
+                self.storage,
                 self.description,
                 hasher.hash_list(sorted(env_hashable.items())),
             ]
@@ -345,6 +366,9 @@ def simple_function_annotation(
     name: str,
     events: List[Event] = [],
     environment={},
+    memory_size: int = 128,
+    timeout: int = 3,
+    storage: int = 512,
     permissions: List[Union[Permission, PermissionArn]] = [],
     override_platform: lambda_python_environment = None,
     includes: List[str] = [],
@@ -356,6 +380,9 @@ def simple_function_annotation(
         name (str): Cdev Name for the function
         events (List[Event], optional): List of event triggers for the function. Defaults to [].
         environment (dict, optional): Dictionary to apply to the Environment Variables of the deployed function. Defaults to {}.
+        memory_size (int, optional): Memory Size of you lambda in MB. Default is 128.
+        timeout (int, optional): Timeout of your lambda in seconds. Default is 3 sec and up to 900.
+        storage (int, optional): Storage of your lambda in MB. Default is 512 MB and can be up to 10240.
         permissions (List[Union[Permission, PermissionArn]], optional): List of Permissions to grant to the Function. Defaults to [].
         override_platform (lambda_python_environment, optional): Option to override the deployment platform in the Cloud. Defaults to None.
         includes (List[str], optional): Set of identifiers to extra global statements to include in parsed artifacts. Defaults to [].
@@ -376,13 +403,14 @@ def simple_function_annotation(
                     description = item[1] if item[1] else ""
                 elif item[0] == "__module__":
                     mod_name = item[1]
-
         final_config = SimpleFunctionConfiguration(
             handler=handler_name,
+            memory_size=memory_size,
+            timeout=timeout,
+            storage=storage,
             description=description,
-            environment_variables=environment,
+            environment_variables=environment
         )
-
         mod = importlib.import_module(mod_name)
 
         full_filepath = os.path.abspath(mod.__file__)

--- a/src/core/utils/fs_manager/finder.py
+++ b/src/core/utils/fs_manager/finder.py
@@ -308,6 +308,9 @@ def _parse_serverless_functions(
 
         new_configuration = SimpleFunctionConfiguration(
             handler=handler_path,
+            memory_size=previous_info.configuration.memory_size,
+            timeout=previous_info.configuration.timeout,
+            storage=previous_info.configuration.storage,
             description=previous_info.configuration.description,
             environment_variables=previous_info.configuration.environment_variables,
         )


### PR DESCRIPTION
We should consider the ergonomics off these options because the Serverless function annotations already takes a toooonnnnn of options.

Add options that set:

- [ ]  Memory Size
- [ ]  Ephemeral Storage
- [ ]  Timeout
    
    

These should be additional properties on the `Serverless Function` resource that are set via the `Servless_function_annotation`

Should use the following `boto3` api for setting the values 

Create → [https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/lambda.html#Lambda.Client.create_function](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/lambda.html#Lambda.Client.create_function).

- `EphemeralStorage`
- `MemorySize`
- `Timeout`

Still missing the Update part
Update → [https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/lambda.html#Lambda.Client.update_function_configuration](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/lambda.html#Lambda.Client.update_function_configuration)

- `EphemeralStorage`
- `MemorySize`
- `Timeout`