### PR TITLE
fix bug where autoscale to 0 was disabled for rds database

### DIFF
--- a/src/core/default/mappers/simple/relational_db_deployer.py
+++ b/src/core/default/mappers/simple/relational_db_deployer.py
@@ -39,7 +39,7 @@ def _create_simple_relational_db(
             "ScalingConfiguration": {
                 "MinCapacity": resource.MinCapacity,
                 "MaxCapacity": resource.MinCapacity,
-                "AutoPause": not resource.SecondsToPause == 0,
+                "AutoPause": resource.SecondsToPause != 0,
                 "SecondsUntilAutoPause": resource.SecondsToPause
                 if not resource.SecondsToPause == 0
                 else 300,

--- a/src/core/default/mappers/simple/relational_db_deployer.py
+++ b/src/core/default/mappers/simple/relational_db_deployer.py
@@ -39,7 +39,7 @@ def _create_simple_relational_db(
             "ScalingConfiguration": {
                 "MinCapacity": resource.MinCapacity,
                 "MaxCapacity": resource.MinCapacity,
-                "AutoPause": resource.SecondsToPause == 0,
+                "AutoPause": not resource.SecondsToPause == 0,
                 "SecondsUntilAutoPause": resource.SecondsToPause
                 if not resource.SecondsToPause == 0
                 else 300,


### PR DESCRIPTION
Found a bug where the RDS Aurora DB autoscale to 0 flag was incorrectly set. This caused the DB that we provisioned in the DEV account to not scale to 0. I caught this early so it only cost $15 so did not rack up too bad a bill. 