### PR TITLE
add list bucket permission and change read_write permissions to have …

### DIFF
--- a/src/core/constructs/cloud_output.py
+++ b/src/core/constructs/cloud_output.py
@@ -948,7 +948,6 @@ class Cloud_Output_Str(Sequence, Cloud_Output_Dynamic):
                 {},
             )
         )
-        print(self._operations)
         return self
 
     def ljust(self, width: SupportsIndex, __fillchar: str = "") -> "Cloud_Output_Str":

--- a/src/core/default/resources/simple/object_store.py
+++ b/src/core/default/resources/simple/object_store.py
@@ -84,38 +84,48 @@ class BucketPermissions:
     RUUID = "cdev::simple::bucket"
 
     def __init__(self, resource_name: str) -> None:
-        self.READ_BUCKET = Permission(
-            actions=["s3:GetObject", "s3:GetObjectVersion", "s3:ListBucket"],
+
+        self.LIST_BUCKET = Permission(
+            actions=["s3:ListBucket"],
             cloud_id=Cloud_Output_Str(
                 resource_name, RUUID, "cloud_id", OutputType.RESOURCE
             ),
+            effect="Allow",
+        )
+        """Permissions to list objects from the `Bucket`"""
+
+        self.READ_BUCKET = Permission(
+            actions=["s3:GetObject", "s3:GetObjectVersion"],
+            cloud_id=Cloud_Output_Str(
+                resource_name, RUUID, "cloud_id", OutputType.RESOURCE
+            ).join(["", "/*"]),
             effect="Allow",
         )
         """Permissions to read objects from the `Bucket`"""
 
         self.WRITE_BUCKET = Permission(
-            actions=["s3:PutObject", "s3:PutObjectAcl", "s3:ListBucket"],
+            actions=["s3:PutObject", "s3:PutObjectAcl"],
             cloud_id=Cloud_Output_Str(
                 resource_name, RUUID, "cloud_id", OutputType.RESOURCE
-            ),
+            ).join(["", "/*"]),
             effect="Allow",
         )
         """Permissions to write objects to the `Bucket`"""
 
         self.READ_AND_WRITE_BUCKET = Permission(
-            actions=["s3:*Object", "s3:ListBucket"],
+            actions=["s3:*Object"],
             cloud_id=Cloud_Output_Str(
                 resource_name, RUUID, "cloud_id", OutputType.RESOURCE
-            ),
+            ).join(["", "/*"]),
             effect="Allow",
         )
         """Permissions to read and write objects to and from the `Bucket`"""
 
         self.READ_EVENTS = Permission(
-            actions=["s3:*Object", "s3:ListBucket"],
+            actions=["s3:*Object"],
             cloud_id=Cloud_Output_Str(
                 resource_name, RUUID, "cloud_id", OutputType.RESOURCE
-            ),
+            ).join(["", "/*"]),
             effect="Allow",
         )
         """Permissions to receive events from the `Bucket`"""


### PR DESCRIPTION
Change the permission of S3 buckets to have an explicit `List  Bucket` permission because the generated policies conflicted when trying to add `List Bucket` with a wildcard `Read Bucket` or `Write Bucket`